### PR TITLE
Add utilities controlling opacity and text break

### DIFF
--- a/src/css/utilities.css
+++ b/src/css/utilities.css
@@ -103,7 +103,7 @@
   text-decoration: none;
 }
 
-/* Utility for prevent long strings of text breaking layout */
+/* Utility for preventing long strings of text breaking layout */
 
 .text-break {
   word-break: break-word !important;

--- a/src/css/utilities.css
+++ b/src/css/utilities.css
@@ -21,6 +21,52 @@
   height: 100vh !important;
 }
 
+/* Utilities for controlling the opacity */
+
+.opacity-0 {
+  opacity: 0;
+}
+
+.opacity-10 {
+  opacity: 0.1;
+}
+
+.opacity-20 {
+  opacity: 0.2;
+}
+
+.opacity-30 {
+  opacity: 0.3;
+}
+
+.opacity-40 {
+  opacity: 0.4;
+}
+
+.opacity-50 {
+  opacity: 0.5;
+}
+
+.opacity-60 {
+  opacity: 0.6;
+}
+
+.opacity-70 {
+  opacity: 0.7;
+}
+
+.opacity-80 {
+  opacity: 0.8;
+}
+
+.opacity-90 {
+  opacity: 0.9;
+}
+
+.opacity-100 {
+  opacity: 1;
+}
+
 /* Utilities for controlling the font size */
 
 .text-xs {

--- a/src/css/utilities.css
+++ b/src/css/utilities.css
@@ -102,3 +102,10 @@
 .no-underline {
   text-decoration: none;
 }
+
+/* Utility for prevent long strings of text breaking layout */
+
+.text-break {
+  word-break: break-word !important;
+  overflow-wrap: break-word !important;
+}


### PR DESCRIPTION
Fix #98 

**Note:** `text-break` Bootstrap's class only available in version >=4.3